### PR TITLE
Upgrade and pin GitHub Actions to latest SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 #v1.0
+        uses: opentap/setup-opentap@c60c3386267d6c8c39d5ad8bd76a219c20f12f33 #fix/upgrade-node-to-node24 (pending v1.1)
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@c60c3386267d6c8c39d5ad8bd76a219c20f12f33 #fix/upgrade-node-to-node24 (pending v1.1)
+        uses: opentap/setup-opentap@2e83d3a5e985a85061d009ac858817c422ee014f #fix/upgrade-node-to-node24 (pending v1.1)
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 # v1.0
+        uses: opentap/setup-opentap@main
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@main
+        uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 #v1.0
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@2e83d3a5e985a85061d009ac858817c422ee014f #fix/upgrade-node-to-node24 (pending v1.1)
+        uses: opentap/setup-opentap@6eee68cf35f2e861f93d21029bbe7af4c427b9bd #main (pending v1.1)
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Fix tags
@@ -23,7 +23,7 @@ jobs:
       - name: Move packages
         run: mv bin/Release/*.TapPackage .
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: package
           retention-days: 5
@@ -37,12 +37,12 @@ jobs:
       - Build
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package
           path: ./
       - name: Setup OpenTAP
-        uses: opentap/setup-opentap@v1.0
+        uses: opentap/setup-opentap@d178a37a089bf73bd99da5b68a00b3d96e6d4517 # v1.0
         with:
           version: 9.18.4
       - name: Install PackagePublish

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,7 +17,7 @@ jobs:
     name: pr-version-comment
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # This action needs the entire history of the repository to calculate the version
           fetch-depth: 0


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full 40-character commit SHAs to reduce supply-chain risk. Both third-party and opentap-owned actions are pinned.

## Changes

All floating tags (e.g. `@v4`, `@main`) replaced with pinned SHAs. opentap-owned actions are pinned to main branch commits pending tagged releases:

- `opentap/setup-opentap` → `6eee68cf35f2e861f93d21029bbe7af4c427b9bd` *(main, pending v1.1)*

## Motivation

Pinning to full SHAs prevents a compromised or accidentally force-pushed tag from silently changing the code that runs in CI. Using the commit SHA of the current `main` branch ensures we get the latest fixes (Node 24 runtime, ubuntu-24.04 runners) while waiting for the upstream `v1.1` tag to be cut.

## Merge order

1. ~~Merge and tag `opentap/setup-opentap#19` as `v1.1`~~ ✅ Merged — tag pending
2. Update the SHA in this PR to the released `v1.1` tag once cut
3. Merge this PR